### PR TITLE
Add git clone to the firmware build instructions

### DIFF
--- a/pico/README.md
+++ b/pico/README.md
@@ -18,6 +18,7 @@ export PICO_SDK_PATH=~/pico-sdk
 
 ## Build the firmware for Apple IIe
 ```shell
+git clone https://github.com/markadev/AppleII-VGA.git ~/AppleII-VGA
 cd ~/AppleII-VGA/pico
 mkdir build
 cd build
@@ -30,6 +31,7 @@ applevga.uf2
 
 ## Build the firmware for Apple II+
 ```shell
+git clone https://github.com/markadev/AppleII-VGA.git ~/AppleII-VGA
 cd /AppleII-VGA/pico
 mkdir build
 cd build


### PR DESCRIPTION
Was helping someone build this firmware and they noticed this command was missing. Obvious to a seasoned git user but handy for users unfamiliar with git. 