### PR TITLE
Fixes for pico-sdk 2.0.0 release

### DIFF
--- a/pico/main.c
+++ b/pico/main.c
@@ -1,5 +1,6 @@
 #include <pico/stdlib.h>
 #include <pico/multicore.h>
+#include <hardware/clocks.h>
 #include "abus.h"
 #include "board_config.h"
 #include "config.h"

--- a/pico/textfont/clone_pravetz_cyrillic.c
+++ b/pico/textfont/clone_pravetz_cyrillic.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://github.com/rallepalaveev/analog/tree/main/Pravetz_font

--- a/pico/textfont/iie_de_improved.c
+++ b/pico/textfont/iie_de_improved.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://downloads.reactivemicro.com/Apple%20II%20Items/ROM_and_JEDEC/IIe/Video%20ROM/Dual-Euro/Apple%20IIe%20Video%20-%20Custom%20-%20Improved%20German-US%20-%20Enhanced%20-%202764.bin

--- a/pico/textfont/iie_fr_ca_enhanced.c
+++ b/pico/textfont/iie_fr_ca_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://downloads.reactivemicro.com/Apple%20II%20Items/ROM_and_JEDEC/IIe/Video%20ROM/Apple%20IIe%20Video%20French%20Canadian%20-%20Enhanced%20-%202732.bin

--- a/pico/textfont/iie_hebrew_enhanced.c
+++ b/pico/textfont/iie_hebrew_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Computers/Apple%20II/Apple%20IIe/ROM%20Images/Apple%20IIe%20Hebrew%20Video%20ROM/rom-a-8k-0

--- a/pico/textfont/iie_it_enhanced.c
+++ b/pico/textfont/iie_it_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://museo.freaknet.org/files/apple-2c/a2-chargen-342-0276-A-2764.bin

--- a/pico/textfont/iie_se_fi_enhanced.c
+++ b/pico/textfont/iie_se_fi_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://mirrors.apple2.org.za/ftp.apple.asimov.net/emulators/rom_images/2764_APPLE-IIe-0341-0162-A_PAL_SWE_FIN.bin

--- a/pico/textfont/iie_spanish_enhanced.c
+++ b/pico/textfont/iie_spanish_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://mirrors.apple2.org.za/ftp.apple.asimov.net/emulators/rom_images/UPD2764D-SpanishIIcCharROM.BIN

--- a/pico/textfont/iie_uk_enhanced.c
+++ b/pico/textfont/iie_uk_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://downloads.reactivemicro.com/Apple%20II%20Items/ROM_and_JEDEC/IIe/Video%20ROM/Dual-Euro/Apple%20IIe%20Video%20UK-US%20-%20Enhanced%20-%20342-0273-A%20-%202764.bin

--- a/pico/textfont/iie_us_enhanced.c
+++ b/pico/textfont/iie_us_enhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") textfont_iie_us_enhanced[256 * 8] = {

--- a/pico/textfont/iie_us_reactive.c
+++ b/pico/textfont/iie_us_reactive.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://downloads.reactivemicro.com/Apple%20II%20Items/ROM_and_JEDEC/IIe/Video%20ROM/Apple%20IIe%20Video%20-%20Enhanced%20-%20ReActive%20-%202732.bin

--- a/pico/textfont/iie_us_unenhanced.c
+++ b/pico/textfont/iie_us_unenhanced.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://downloads.reactivemicro.com/Apple%20II%20Items/ROM_and_JEDEC/IIe/Video%20ROM/Apple%20IIe%20Video%20-%20Unenhanced%20-%20342-0133-A%20-%202732.bin

--- a/pico/textfont/iiplus_jp_katakana.c
+++ b/pico/textfont/iiplus_jp_katakana.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Computers/Apple%20II/Apple%20II%20j-plus/ROM%20Images/Apple%20II%20j-plus%20Video%20ROM.bin

--- a/pico/textfont/iiplus_pigfont.c
+++ b/pico/textfont/iiplus_pigfont.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://downloads.reactivemicro.com/Apple%20II%20Items/ROM_and_JEDEC/II_&_II+/Apple%20II+%20-%20Pig%20Font%20Character%20Generator%20-%202716.bin

--- a/pico/textfont/iiplus_us.c
+++ b/pico/textfont/iiplus_us.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") textfont_iiplus_us[256 * 8] = {

--- a/pico/textfont/iiplus_videx_lowercase1.c
+++ b/pico/textfont/iiplus_videx_lowercase1.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Interface%20Cards/80%20Column%20Cards/Videx%20Videoterm/ROM%20Images/ROM%20dump%20-%20Apple%202plus%20character%20generator%20-%20possibly%20Videx%20lowercase%20chip.bin

--- a/pico/textfont/iiplus_videx_lowercase2.c
+++ b/pico/textfont/iiplus_videx_lowercase2.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 // https://mirrors.apple2.org.za/Apple%20II%20Documentation%20Project/Chips/Videx%20Lower%20Case%20Chip/ROM%20Images/Videx%20Lower%20Case%20Chip%20ROM.bin

--- a/pico/textfont/videx_apl.c
+++ b/pico/textfont/videx_apl.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_apl[128 * 16] = {

--- a/pico/textfont/videx_epson.c
+++ b/pico/textfont/videx_epson.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_epson[128 * 16] = {

--- a/pico/textfont/videx_french.c
+++ b/pico/textfont/videx_french.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_french[128 * 16] = {

--- a/pico/textfont/videx_german.c
+++ b/pico/textfont/videx_german.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_german[128 * 16] = {

--- a/pico/textfont/videx_inverse.c
+++ b/pico/textfont/videx_inverse.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_inverse[128 * 16] = {

--- a/pico/textfont/videx_katakana.c
+++ b/pico/textfont/videx_katakana.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_katakana[128 * 16] = {

--- a/pico/textfont/videx_normal.c
+++ b/pico/textfont/videx_normal.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_normal[128 * 16] = {

--- a/pico/textfont/videx_spanish.c
+++ b/pico/textfont/videx_spanish.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_spanish[128 * 16] = {

--- a/pico/textfont/videx_super_sub.c
+++ b/pico/textfont/videx_super_sub.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_super_sub[128 * 16] = {

--- a/pico/textfont/videx_symbol.c
+++ b/pico/textfont/videx_symbol.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_symbol[128 * 16] = {

--- a/pico/textfont/videx_uppercase.c
+++ b/pico/textfont/videx_uppercase.c
@@ -1,5 +1,5 @@
 #include "textfont.h"
-#include <pico/platform.h>
+#include <pico.h>
 
 
 const uint8_t __in_flash("chr_rom") videx_uppercase[128 * 16] = {


### PR DESCRIPTION
Without these changes, building against pico-sdk 2.0.0 will produce the following errors ...

1. Per [Should we guard against including pico/platform.h #1664](https://github.com/raspberrypi/pico-sdk/issues/1664)

```
In file included from AppleII-VGA/pico/textfont/{fontfile}.c:2:

error: #error pico/platform.h should not be included directly; include pico.h instead
```

2. Per [Release notes - set_sys_clock_ functions are now in hardware/clocks.h](https://github.com/raspberrypi/pico-sdk/releases/tag/2.0.0)
```
AppleII-VGA/pico/main.c:18: undefined reference to `set_sys_clock_khz'
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/applevga.dir/build.make:1672: applevga.elf] Error 1
make[1]: *** [CMakeFiles/Makefile2:1748: CMakeFiles/applevga.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

